### PR TITLE
Add vehicle availability endpoint and UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "reservation-ui",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/src/VehicleReservation.jsx
+++ b/frontend/src/VehicleReservation.jsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+
+function VehicleReservation({ token }) {
+  const [vehicles, setVehicles] = useState([]);
+  const [selectedVehicle, setSelectedVehicle] = useState(null);
+  const [availability, setAvailability] = useState([]);
+  const [selectedDate, setSelectedDate] = useState(null);
+  const [selectedHour, setSelectedHour] = useState(null);
+
+  useEffect(() => {
+    fetch('/vehicles')
+      .then(res => res.json())
+      .then(setVehicles);
+  }, []);
+
+  const loadAvailability = async (vehicleId) => {
+    const today = new Date().toISOString().slice(0,10);
+    const resp = await fetch(`/vehicles/${vehicleId}/availability?startDate=${today}&days=7`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+    const data = await resp.json();
+    setAvailability(data.availability);
+  };
+
+  const selectVehicle = (v) => {
+    setSelectedVehicle(v);
+    setSelectedDate(null);
+    setSelectedHour(null);
+    loadAvailability(v.id);
+  };
+
+  const hours = Array.from({length:24}, (_,i) => i);
+
+  const isPast = (dateStr, hour) => {
+    const now = new Date();
+    const date = new Date(dateStr + 'T00:00:00');
+    if (date.toDateString() !== now.toDateString()) return false;
+    return hour <= now.getHours();
+  };
+
+  const dayAvailability = availability.find(a => a.date === selectedDate);
+  const bookedHours = dayAvailability ? dayAvailability.bookedHours : [];
+
+  return (
+    <div>
+      <h2>Vehicles</h2>
+      <div style={{display:'flex',gap:'1rem'}}>
+        {vehicles.map(v => (
+          <div key={v.id} onClick={() => selectVehicle(v)} style={{cursor:'pointer', border: v===selectedVehicle ? '2px solid blue' : '1px solid #ccc'}}>
+            <img src={v.imageUrl} alt={v.name} width={100} />
+            <div>{v.name}</div>
+          </div>
+        ))}
+      </div>
+
+      {selectedVehicle && (
+        <div>
+          <h3>Select Day</h3>
+          <div style={{display:'flex', gap:'0.5rem'}}>
+            {availability.map(a => {
+              const fullyBooked = a.bookedHours.length === 24;
+              return (
+                <button key={a.date} onClick={() => setSelectedDate(a.date)} disabled={fullyBooked} style={{background: a.date===selectedDate ? '#add8e6':'white'}}>
+                  {a.date}{fullyBooked ? ' (Full)' : ''}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {selectedDate && (
+        <div>
+          <h3>Select Hour</h3>
+          <div style={{display:'flex', flexWrap:'wrap', gap:'0.5rem'}}>
+            {hours.map(h => {
+              const disabled = bookedHours.includes(h) || isPast(selectedDate, h);
+              return (
+                <button key={h} onClick={() => setSelectedHour(h)} disabled={disabled} style={{width:'60px', background: selectedHour===h ? '#add8e6' : undefined, cursor: disabled ? 'not-allowed':'pointer', opacity: disabled ? 0.5:1}}>
+                  {h}:00
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {selectedHour !== null && (
+        <button>Next</button>
+      )}
+    </div>
+  );
+}
+
+export default VehicleReservation;

--- a/src/main/java/com/inptrental/inptrental/controller/AvailabilityController.java
+++ b/src/main/java/com/inptrental/inptrental/controller/AvailabilityController.java
@@ -1,0 +1,26 @@
+package com.inptrental.inptrental.controller;
+
+import com.inptrental.inptrental.dto.AvailabilityResponse;
+import com.inptrental.inptrental.service.AvailabilityService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/vehicles")
+public class AvailabilityController {
+
+    private final AvailabilityService availabilityService;
+
+    public AvailabilityController(AvailabilityService availabilityService) {
+        this.availabilityService = availabilityService;
+    }
+
+    @GetMapping("/{vehicleId}/availability")
+    public AvailabilityResponse getAvailability(@PathVariable Long vehicleId,
+                                                 @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                                 @RequestParam(defaultValue = "7") int days) {
+        return availabilityService.getAvailability(vehicleId, startDate, days);
+    }
+}

--- a/src/main/java/com/inptrental/inptrental/dto/AvailabilityResponse.java
+++ b/src/main/java/com/inptrental/inptrental/dto/AvailabilityResponse.java
@@ -1,0 +1,13 @@
+package com.inptrental.inptrental.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class AvailabilityResponse {
+    private Long vehicleId;
+    private List<DayAvailability> availability;
+}

--- a/src/main/java/com/inptrental/inptrental/dto/DayAvailability.java
+++ b/src/main/java/com/inptrental/inptrental/dto/DayAvailability.java
@@ -1,0 +1,14 @@
+package com.inptrental.inptrental.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class DayAvailability {
+    private LocalDate date;
+    private List<Integer> bookedHours;
+}

--- a/src/main/java/com/inptrental/inptrental/model/Reservation.java
+++ b/src/main/java/com/inptrental/inptrental/model/Reservation.java
@@ -1,0 +1,23 @@
+package com.inptrental.inptrental.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Entity
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vehicle_id")
+    private Vehicle vehicle;
+
+    private OffsetDateTime startTime;
+
+    private OffsetDateTime endTime;
+}

--- a/src/main/java/com/inptrental/inptrental/model/Vehicle.java
+++ b/src/main/java/com/inptrental/inptrental/model/Vehicle.java
@@ -3,16 +3,18 @@ package com.inptrental.inptrental.model;
 import jakarta.persistence.*;
 import lombok.Data;
 
-@Entity
 @Data
+@Entity
 public class Vehicle {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
-
     private String type; // "Scooter" or "Velo"
     private String status; // "Available" or "Rented" or "Unavailable"
+
+    private String imageUrl;
 }

--- a/src/main/java/com/inptrental/inptrental/repository/ReservationRepository.java
+++ b/src/main/java/com/inptrental/inptrental/repository/ReservationRepository.java
@@ -1,0 +1,17 @@
+package com.inptrental.inptrental.repository;
+
+import com.inptrental.inptrental.model.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    @Query("SELECT r FROM Reservation r WHERE r.vehicle.id = :vehicleId AND r.startTime < :end AND r.endTime > :start")
+    List<Reservation> findOverlappingReservations(@Param("vehicleId") Long vehicleId,
+                                                  @Param("start") OffsetDateTime start,
+                                                  @Param("end") OffsetDateTime end);
+}

--- a/src/main/java/com/inptrental/inptrental/service/AvailabilityService.java
+++ b/src/main/java/com/inptrental/inptrental/service/AvailabilityService.java
@@ -1,0 +1,48 @@
+package com.inptrental.inptrental.service;
+
+import com.inptrental.inptrental.dto.AvailabilityResponse;
+import com.inptrental.inptrental.dto.DayAvailability;
+import com.inptrental.inptrental.model.Reservation;
+import com.inptrental.inptrental.repository.ReservationRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.util.*;
+
+@Service
+public class AvailabilityService {
+
+    private final ReservationRepository reservationRepository;
+
+    public AvailabilityService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
+    }
+
+    public AvailabilityResponse getAvailability(Long vehicleId, LocalDate startDate, int days) {
+        List<DayAvailability> result = new ArrayList<>();
+        ZoneOffset zone = ZoneOffset.UTC;
+        for (int i = 0; i < days; i++) {
+            LocalDate current = startDate.plusDays(i);
+            OffsetDateTime dayStart = current.atStartOfDay().atOffset(zone);
+            OffsetDateTime dayEnd = dayStart.plusDays(1);
+
+            List<Reservation> reservations = reservationRepository.findOverlappingReservations(vehicleId, dayStart, dayEnd);
+            Set<Integer> booked = new HashSet<>();
+
+            for (Reservation res : reservations) {
+                OffsetDateTime start = res.getStartTime().isBefore(dayStart) ? dayStart : res.getStartTime();
+                OffsetDateTime end = res.getEndTime().isAfter(dayEnd) ? dayEnd : res.getEndTime();
+
+                int startHour = start.getHour();
+                int endHour = end.minusSeconds(1).getHour();
+                for (int h = startHour; h <= endHour; h++) {
+                    booked.add(h);
+                }
+            }
+            List<Integer> bookedHours = new ArrayList<>(booked);
+            Collections.sort(bookedHours);
+            result.add(new DayAvailability(current, bookedHours));
+        }
+        return new AvailabilityResponse(vehicleId, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add Reservation entity and availability service
- expose `/vehicles/{vehicleId}/availability` endpoint
- sample React UI to display vehicles and hourly availability

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e430976408328ae7ca32de496160b